### PR TITLE
feat: Support review timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Telegram 投稿/审稿机器人，基于 Telegram Bot API 7.1 以及 python-tele
 | `TG_TEXT_SPOILER`             | 是否为 NSFW 投稿的文字添加遮罩                                                                                                                      | `True` 或 `False`                      | 否，默认为 True                                                |
 | `TG_EXPAND_LENGTH`            | 文字长度大于多少时进行折叠                                                                                                                          | `200`                                  | 否，默认为 200                                                 |
 | `TG_SELF_APPROVE`             | 是否允许审核给自己的稿件投通过票，True 为允许，False 为禁止                                                                                         | `True` 或 `False`                      | 否，默认为 True                                                |
+| `TG_TIMEOUT_SINGLEREVIEW`     | 超过设定时间后，投稿仅需 1 次审核就能通过或拒绝       | `10080` | 否，默认为 `10080`，若要禁用请设置为较大值 |
 
 请确保在使用项目前正确设置这些环境变量，以保证程序的正常运行。对于标记为“是”的变量，它们是项目运行所必需的，而对于标记为“否”的变量，则为可选配置，如果未设置，项目将使用默认值或不执行相关功能。
 

--- a/env.py
+++ b/env.py
@@ -28,3 +28,4 @@ TG_SINGLE_MODE = os.getenv("TG_SINGLE_MODE", "True") == "True"
 TG_TEXT_SPOILER = os.getenv("TG_TEXT_SPOILER", "True") == "True"
 TG_EXPAND_LENGTH = int(os.getenv("TG_EXPAND_LENGTH", 200))
 TG_SELF_APPROVE = os.getenv("TG_SELF_APPROVE", "True") == "True"
+TG_TIMEOUT_SINGLEREVIEW = int(os.getenv("TG_TIMEOUT_SINGLEREVIEW", "10080"))

--- a/review_utils.py
+++ b/review_utils.py
@@ -571,7 +571,7 @@ def get_submission_status(submission_meta):
     return status, rejection_reason
 
 
-def generate_submission_meta_string(submission_meta):
+def generate_submission_meta_string(submission_meta,longago_approve=False):
     # generate the submission_meta string from the submission_meta
     # approved submission string style:
     """
@@ -626,6 +626,8 @@ def generate_submission_meta_string(submission_meta):
 
     # get status and rejection reason
     status, rejection_reason = get_submission_status(submission_meta)
+    if longago_approve:
+        status = SubmissionStatus.APPROVED
     # submitter_string
     submitter_id, submitter_username, submitter_fullname, _ = submission_meta[
         "submitter"


### PR DESCRIPTION
加入配置 `TG_TIMEOUT_SINGLEREVIEW` ，单位为分钟，默认值为 `10080`（一周）。在处理审核操作时，查询投稿时间距今是否超过 `TG_TIMEOUT_SINGLEREVIEW`，若超过则无视 `APPROVE_NUMBER_REQUIRED` 和 `REJECT_NUMBER_REQUIRED` 的限制，并且在 `generate_submission_meta_string` 时加入 `longago_approve` 判断条件以使得超时的投稿能正确判断审核通过状态。