### PR TITLE
refactor: 通用用户信息生成函数 generate_userinfo_str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,8 @@ cython_debug/
 
 # VSCode
 .vscode
+
+# File system
+desktop.ini
+.DS_Store
+._.DS_Store

--- a/ban.py
+++ b/ban.py
@@ -145,12 +145,12 @@ async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
     Banned_user.unban_user(user)
     if Banned_user.is_banned(user):
         await update.message.reply_text(
-            f"*{user}* 解除屏蔽失败",
+            f"`{user}` 解除屏蔽失败",
             parse_mode=ParseMode.MARKDOWN_V2,
         )
     else:
         await update.message.reply_text(
-            f"*{user}* "
+            f"`{user}` "
             + escape_markdown(
                 f"已解除屏蔽\n\n#UNBAN_{user} #USER_{user} #OPERATOR_{update.effective_user.id}",
                 version=2,

--- a/ban.py
+++ b/ban.py
@@ -4,7 +4,7 @@ from telegram.ext import ContextTypes
 from telegram.helpers import escape_markdown
 
 from db_op import Banned_origin, Banned_user
-from utils import get_name_from_uid, is_integer, sanitize_userinfo
+from utils import get_name_from_uid, is_integer, generate_userinfo_str
 
 import re
 
@@ -93,27 +93,12 @@ async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
 
 
-async def get_banned_user_info(context: ContextTypes.DEFAULT_TYPE, user):
-    banned_userinfo = (
-        "*"
-        + escape_markdown(sanitize_userinfo(user.user_fullname), version=2)
-        + "* \\("
-        + (f"@{escape_markdown(user.user_name, version=2)}, " if user.user_name else "")
-        + "`"
-        + user.user_id
-        + "`\\)"
-    )
+async def get_banned_user_info(context: ContextTypes.DEFAULT_TYPE, user, mention = True):
+    banned_userinfo = generate_userinfo_str(id=int(user.user_id),username=user.user_name,fullname=user.user_fullname,boldfullname=True,mention=mention)
     banned_by_username, banned_by_fullname = await get_name_from_uid(
         context, user.banned_by
     )
-    banned_by_userinfo = (
-        escape_markdown(sanitize_userinfo(banned_by_fullname), version=2)
-        + " \\(@"
-        + escape_markdown(banned_by_username, version=2)
-        + ", `"
-        + user.banned_by
-        + "`\\)"
-    )
+    banned_by_userinfo = generate_userinfo_str(id=int(user.banned_by),username=banned_by_username,fullname=banned_by_fullname,boldfullname=True,mention=mention)
     users_string = f"{banned_userinfo}\n  在 {escape_markdown(str(user['banned_date']), version=2)}\n  由 {banned_by_userinfo}\n  因 `{escape_markdown(user['banned_reason'], version=2)}` 屏蔽"
     return users_string
 
@@ -181,7 +166,7 @@ async def list_banned_users(
     list_banned_users_page_count = 1
     users_string = ("屏蔽用户列表:\n\\=\\= 页面" + str(list_banned_users_page_count) + " \\=\\=\n") if users else "无屏蔽用户\n"
     for user in users:
-        new_banned_usr_str = f"\\- {await get_banned_user_info(context, user)}\n"
+        new_banned_usr_str = f"\\- {await get_banned_user_info(context, user, mention=False)}\n"
         if len(users_string + new_banned_usr_str) >= 1300:
             users_string += "（未完待续）"
             await update.message.reply_text(
@@ -249,10 +234,10 @@ async def ban_origin(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def get_banned_origin_info(context: ContextTypes.DEFAULT_TYPE, origin):
     banned_origininfo = f"`{origin.origin_id}`"
-    banned_by_originname, banned_by_fullname = await get_name_from_uid(
+    banned_by_username, banned_by_fullname = await get_name_from_uid(
         context, origin.banned_by
     )
-    banned_by_origininfo = f"{escape_markdown(sanitize_userinfo(banned_by_fullname),version=2)} \\(@{escape_markdown(banned_by_originname,version=2)}, `{origin.banned_by}`\\)"
+    banned_by_origininfo = generate_userinfo_str(id=int(origin.banned_by),fullname=banned_by_fullname,username=banned_by_username)
     origins_string = f"{banned_origininfo}\n  在 {escape_markdown(str(origin['banned_date']), version=2)}\n  由 {banned_by_origininfo}\n  因 `{escape_markdown(origin['banned_reason'], version=2)}` 屏蔽"
     return origins_string
 

--- a/ban.py
+++ b/ban.py
@@ -6,12 +6,14 @@ from telegram.helpers import escape_markdown
 from db_op import Banned_origin, Banned_user
 from utils import get_name_from_uid, is_integer, sanitize_userinfo
 
+import re
 
 async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not context.args:
         # need at least reason even if user is from reply
         await update.message.reply_text(
-            "请提供用户ID和原因",
+            "使用方法：\n`/ban <usrid> reason`",
+            parse_mode=ParseMode.MARKDOWN_V2,
         )
         return
     user, result = context.args[0], context.args[1:]
@@ -21,23 +23,28 @@ async def ban_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
         elif user.startswith("#SUBMITTER_"):
             user = user[11:]
 
+    # only reason, no userid. so `user` is just reason
     if not user.isdigit():
         if update.message.reply_to_message:
             replyto_user_id = str(update.message.reply_to_message.from_user.id)
             self_id = str((await context.bot.get_me()).id)
             if replyto_user_id == self_id:
+                tag_unban_id = re.findall(r"#UNBAN_(\d+)", update.message.reply_to_message.text)
                 tag_submitter_id = re.findall(r"#SUBMITTER_(\d+)", update.message.reply_to_message.text)
-                if tag_submitter_id:
-                    result = context.args
-                    user = tag_submitter_id[-1]
+                if tag_unban_id:
+                    result = user
+                    user = tag_unban_id[0]
+                elif tag_submitter_id:
+                    result = user
+                    user = tag_submitter_id[0]
                 else:
-                    update.message.reply_text(
+                    await update.message.reply_text(
                         f"ID *{escape_markdown(user,version=2,)}* 无效，且回复的消息中无投稿人信息。",
                         parse_mode=ParseMode.MARKDOWN_V2,
                     )
                     return
             else:
-                update.message.reply_text(
+                await update.message.reply_text(
                     f"ID *{escape_markdown(user,version=2,)}* 无效，且回复的消息不是投稿机器人消息。",
                     parse_mode=ParseMode.MARKDOWN_V2,
                 )
@@ -113,11 +120,27 @@ async def get_banned_user_info(context: ContextTypes.DEFAULT_TYPE, user):
 
 async def unban_user(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not context.args:
-        await update.message.reply_text(
-            "请提供用户ID",
-        )
-        return
-    user = context.args[0]
+        if update.message.reply_to_message:
+            tag_ban_id = re.findall(r"#BAN_(\d+)", update.message.reply_to_message.text)
+            tag_submitter_id = re.findall(r"#SUBMITTER_(\d+)", update.message.reply_to_message.text)
+            if tag_ban_id:
+                user = tag_ban_id[0]
+            elif tag_submitter_id:
+                user = tag_submitter_id[0]
+            else:
+                await update.message.reply_text(
+                    "使用方法：\n`/unban <usrid>`",
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                )
+                return
+        else:
+            await update.message.reply_text(
+                "使用方法：\n`/unban <usrid>`",
+                parse_mode=ParseMode.MARKDOWN_V2,
+            )
+            return
+    else:
+        user = context.args[0]
 
     if user.startswith(("#USER_","#SUBMITTER_","#BAN_")):
         if user.startswith("#USER_"):

--- a/db_op.py
+++ b/db_op.py
@@ -127,6 +127,8 @@ class Submitter(Base):
                 cur_submitter.max_submission_per_hour,
                 cur_submitter.count_from_last_hour,
             )
+            if isinstance(last_submit, str):
+                last_submit = datetime.strptime(last_submit, "%Y-%m-%d %H:%M:%S.%f")
             next_hour_begin = last_submit.replace(
                 minute=0, second=0, microsecond=0
             ) + timedelta(hours=1)
@@ -158,6 +160,8 @@ class Submitter(Base):
                 cur_submitter.max_submission_per_hour,
                 cur_submitter.count_from_last_hour,
             )
+            if isinstance(last_submit, str):
+                last_submit = datetime.strptime(last_submit, "%Y-%m-%d %H:%M:%S.%f")
             next_hour_begin = last_submit.replace(
                 minute=0, second=0, microsecond=0
             ) + timedelta(hours=1)

--- a/review_utils.py
+++ b/review_utils.py
@@ -17,7 +17,7 @@ from env import (
     TG_REJECTED_CHANNEL,
     TG_RETRACT_NOTIFY,
 )
-from utils import send_result_to_submitter, send_submission, sanitize_userinfo
+from utils import send_result_to_submitter, send_submission, sanitize_userinfo, generate_userinfo_str
 
 """
 submission_meta = {
@@ -630,7 +630,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     submitter_id, submitter_username, submitter_fullname, _ = submission_meta[
         "submitter"
     ]
-    submitter_string = f"投稿人：{submitter_fullname} ({f'@{submitter_username}, ' if submitter_username else ''}{submitter_id})\n"
+    submitter_string = f"投稿人：{generate_userinfo_str(id=int(submitter_id),username=submitter_username,fullname=submitter_fullname)}\n"
 
     # reviewers_string
     is_nsfw = False
@@ -661,7 +661,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
                         f"因为 {get_rejection_reason_text(option)} 拒稿"
                     )
                     option_sign = "🔴"
-            reviewers_string += f"\n- {option_sign} 由 {reviewer_fullname} ({f'@{reviewer_username}, ' if reviewer_username else ''}{reviewer_id}) {option_text}"
+            reviewers_string += f"\n\\- {option_sign} 由 {generate_userinfo_str(id=int(reviewer_id),fullname=reviewer_fullname,username=reviewer_username)} {escape_markdown(option_text,version=2)}"
 
     # append_string
     append_string = "审稿人备注："

--- a/review_utils.py
+++ b/review_utils.py
@@ -658,7 +658,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
                     option_sign = "🔴"
                 case _:
                     option_text = (
-                        f"因为 {get_rejection_reason_text(option)} 拒稿"
+                        f"因为 {escape_markdown(get_rejection_reason_text(option),version=2)} 拒稿"
                     )
                     option_sign = "🔴"
             reviewers_string += f"\n\\- {option_sign} 由 {generate_userinfo_str(id=int(reviewer_id),fullname=reviewer_fullname,username=reviewer_username)} {escape_markdown(option_text,version=2)}"
@@ -666,12 +666,15 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     # append_string
     append_string = "审稿人备注："
     for reviewer_fullname, append_list in submission_meta["append"].items():
-        append_string += f"\n - 由 {sanitize_userinfo(escape_markdown(reviewer_fullname),version=2)} 添加的备注："
+        append_string += f"\n \\- 由 {sanitize_userinfo(escape_markdown(reviewer_fullname,version=2))} 添加的备注："
         append_string += "".join(
-            f"\n{i+1}. {message}" for i, message in enumerate(append_list)
+            f"\n{i+1}\\. {escape_markdown(message,version=2)}" for i, message in enumerate(append_list)
         )
+
     if append_string == "审稿人备注：":
         append_string = ""
+    else:
+        append_string = "\n" + append_string + "\n"
 
     # status_string and status_tag
     status_string = ""
@@ -684,7 +687,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
             status_string = "以 NSFW 通过" if is_nsfw else "以 SFW 通过"
             status_tag = "#APPROVED #SFW" if not is_nsfw else "#APPROVED #NSFW"
         case SubmissionStatus.REJECTED:
-            status_string = f"因为 {rejection_reason} 被拒稿"
+            status_string = f"因为 {escape_markdown(rejection_reason,version=2)} 被拒稿"
             status_tag = "#REJECTED"
         case SubmissionStatus.REJECTED_NO_REASON:
             status_string = "被拒稿，待选择理由"
@@ -708,19 +711,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     tags += f" {status_tag}"
 
     submission_meta_text = f"[\u200b](http://t.me/{base64.urlsafe_b64encode(pickle.dumps(submission_meta)).decode()})"
-    visible_content = escape_markdown(
-        dedent(
-            f"""\
-{status_title}
+    visible_content = dedent(status_title + "\n\n" + submitter_string + "\n" + reviewers_string + "\n" + append_string + "\n当前状态：" + status_string + "\n\n" + escape_markdown(tags,version=2))
 
-{submitter_string}
-{reviewers_string}
-{append_string}
-当前状态：{status_string}
-
-{tags}"""
-        ),
-        version=2,
-    )
     # use Zero-width non-joiner and fake url(or the bot api will delete invalid link) to hide the submission_meta
     return f"{visible_content}{submission_meta_text}"

--- a/review_utils.py
+++ b/review_utils.py
@@ -1,6 +1,5 @@
 import base64
 import pickle
-from textwrap import dedent
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ParseMode
@@ -668,7 +667,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     for reviewer_fullname, append_list in submission_meta["append"].items():
         append_string += f"\n \\- 由 {sanitize_userinfo(escape_markdown(reviewer_fullname,version=2))} 添加的备注："
         append_string += "".join(
-            f"\n{i+1}\\. {escape_markdown(message,version=2)}" for i, message in enumerate(append_list)
+            f"\n    {i+1}\\. {escape_markdown(message,version=2)}" for i, message in enumerate(append_list)
         )
 
     if append_string == "审稿人备注：":
@@ -711,7 +710,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     tags += f" {status_tag}"
 
     submission_meta_text = f"[\u200b](http://t.me/{base64.urlsafe_b64encode(pickle.dumps(submission_meta)).decode()})"
-    visible_content = dedent(status_title + "\n\n" + submitter_string + "\n" + reviewers_string + "\n" + append_string + "\n当前状态：" + status_string + "\n\n" + escape_markdown(tags,version=2))
+    visible_content = status_title + "\n\n" + submitter_string + "\n" + reviewers_string + "\n" + append_string + "\n当前状态：" + status_string + "\n\n" + escape_markdown(tags,version=2)
 
     # use Zero-width non-joiner and fake url(or the bot api will delete invalid link) to hide the submission_meta
     return f"{visible_content}{submission_meta_text}"

--- a/review_utils.py
+++ b/review_utils.py
@@ -17,7 +17,7 @@ from env import (
     TG_REJECTED_CHANNEL,
     TG_RETRACT_NOTIFY,
 )
-from utils import send_result_to_submitter, send_submission
+from utils import send_result_to_submitter, send_submission, sanitize_userinfo
 
 """
 submission_meta = {
@@ -666,7 +666,7 @@ def generate_submission_meta_string(submission_meta, longago_status=0):
     # append_string
     append_string = "审稿人备注："
     for reviewer_fullname, append_list in submission_meta["append"].items():
-        append_string += f"\n - 由 {reviewer_fullname} 添加的备注："
+        append_string += f"\n - 由 {sanitize_userinfo(escape_markdown(reviewer_fullname),version=2)} 添加的备注："
         append_string += "".join(
             f"\n{i+1}. {message}" for i, message in enumerate(append_list)
         )

--- a/stats.py
+++ b/stats.py
@@ -21,7 +21,7 @@ async def submitter_stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 if replyto_user_id == self_id:
                     tag_submitter_id = re.findall(r"#SUBMITTER_(\d+)", update.message.reply_to_message.text)
                     if tag_submitter_id:
-                        submitter_id = tag_submitter_id[-1]
+                        submitter_id = tag_submitter_id[0]
                     else:
                         update.message.reply_text("请提供用户ID")
                         return

--- a/utils.py
+++ b/utils.py
@@ -11,6 +11,7 @@ from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 from telegram.ext.filters import MessageFilter
 from db_op import Banned_origin, Banned_user, Submitter
+from telegram.helpers import escape_markdown
 from env import TG_BANNED_NOTIFY, TG_TEXT_SPOILER
 
 
@@ -213,6 +214,36 @@ async def get_name_from_uid(context, user_id):
     except Exception as e:
         print(e)
         return "", ""
+
+
+def generate_userinfo_str(
+        id: int, fullname: str | None = None,
+        username: str | None = None,
+        mention: bool = True,
+        boldfullname: bool = False
+    ) -> str:
+    userinfo_str = ""
+
+    if fullname is not None:
+        if boldfullname:
+            userinfo_str += ("*" + sanitize_userinfo(escape_markdown(fullname,version = 2)) + "*")
+        else:
+            userinfo_str += sanitize_userinfo(escape_markdown(fullname,version = 2))
+    else:
+        userinfo_str += "*_神秘用户_*"
+
+    userinfo_str += " \\("
+
+    if username is not None:
+        if mention:
+            userinfo_str += ("@" + escape_markdown(username, version = 2))
+        else:
+            userinfo_str += ("`" + escape_markdown(username, version = 2) + "`")
+        userinfo_str += ", "
+
+    userinfo_str += "`" + str(id) + "`\\)"
+
+    return userinfo_str
 
 
 async def check_submission(update):

--- a/utils.py
+++ b/utils.py
@@ -226,7 +226,11 @@ def generate_userinfo_str(
 
     if fullname is not None:
         if boldfullname:
-            userinfo_str += ("*" + sanitize_userinfo(escape_markdown(fullname,version = 2)) + "*")
+            fullname_sanitized = sanitize_userinfo(escape_markdown(fullname,version = 2))
+            if fullname_sanitized.startswith("*"):
+                userinfo_str += fullname_sanitized
+            else:
+                userinfo_str += ("*" + fullname_sanitized + "*")
         else:
             userinfo_str += sanitize_userinfo(escape_markdown(fullname,version = 2))
     else:

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-import collections
+import collections, re
 
 from telegram import (
     InputMediaDocument,
@@ -273,7 +273,9 @@ def is_integer(s):
         return False
 
 def sanitize_userinfo(text: str) -> str:
-    import re
     if not text:
-        return ""
-    return re.sub(r'[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF\x00-\x1F\x7F\x80-\x9F]', '', text).strip()
+        return "*_空白用户名_*"
+    userinfo = re.sub(r'[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF\x00-\x1F\x7F\x80-\x9F]', '', text).strip()
+    if userinfo == "":
+        userinfo = "*_空白用户名_*"
+    return userinfo


### PR DESCRIPTION
加入通用用户信息生成函数 `generate_userinfo_str` （位于 `utils.py`），并修复下列 bug：

1. 向 `.gitignore` 加入文件系统相关内容
2. `ban.py` 中未导入 `re` 包但使用了 `re` 相关功能
3. `ban_user` 中错误命令的回应时应 await 但是没有 await
4. `ban_user` `unban_user` 和 `submitter_stats` 中对回复消息中 tag 读取处理的问题
5. `generate_submission_meta_string` 中未对审核用户名做合适的转义
6. `sanitize_userinfo` 对空白名称标识的问题
7. 在使用 SQLite 时 `last_submit` 以字符串存储但以字符串读取的问题
8. 改进 `review_utils.py` 中 `visible_content` 的生成方式，以适配含markdown的内容
9. `/unban` 时用户 ID 未等宽而被识别为电话号码