### PR TITLE
func: 通过启动参数选择 debug 等级

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import logging
+import logging, argparse
 
 from telegram.ext import (
     ApplicationBuilder,
@@ -6,6 +6,20 @@ from telegram.ext import (
     CommandHandler,
     MessageHandler,
     filters,
+)
+
+arg_parser = argparse.ArgumentParser(description="FOO")
+arg_parser.add_argument("--debug", nargs="?", const="INFO", help="Debug Level. (DEBUG/INFO/WARNING(default)/ERROR)")
+
+args = arg_parser.parse_args()
+log_level = args.debug if args.debug else "WARNING"
+if log_level.upper() not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+    print(f"VALUE OF \"--debug\" NOT SUPPORT TO BE '{log_level}'. EXIT.")
+    sys.exit(1)
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=getattr(logging, log_level.upper())
 )
 
 from ban import (


### PR DESCRIPTION
## 选择 debug 等级
### 实现方式
- 在 main.py 引入 argparse。
- 新增启动参数 --debug：
  - 可不带值使用，默认按 INFO 处理（const="INFO"）。
  - 带值时支持：DEBUG / INFO / WARNING / ERROR / CRITICAL（大小写不敏感）。
  - 未传参时默认日志级别为 WARNING。
- 启动时根据参数设置 logging.basicConfig(level=...)。
- 当传入不支持的日志级别时，输出错误信息并以非 0 状态退出。
### 使用示例
- 默认级别（WARNING）：
python main.py
- 指定 INFO：
  - python main.py --debug
  - python main.py --debug INFO
- 指定 DEBUG：
  - python main.py --debug DEBUG